### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -12,7 +12,7 @@ jobs:
   check-version:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Get versions
         id: versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Test action
         uses: ./
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: First run (cache miss)
         uses: ./
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Test with SIGV4 enabled
         uses: ./
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Test with verification enabled
         uses: ./
@@ -99,7 +99,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Test action (should fail gracefully)
         id: test

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run Linter
         run: pipx run ruff check --output-format=json . > lint.json || true

--- a/examples/tier1-maximum-security.yml
+++ b/examples/tier1-maximum-security.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Lint Code
         run: pipx run ruff check --output-format=json . > lint.json || true

--- a/examples/tier2-balanced-security.yml
+++ b/examples/tier2-balanced-security.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -50,12 +50,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Download Review Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ai-review
 
       - name: Post Review Comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/examples/tier3-advanced-patterns.yml
+++ b/examples/tier3-advanced-patterns.yml
@@ -13,7 +13,7 @@ jobs:
       github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Updates

- `actions/checkout@v5` → `v6`
- `actions/download-artifact@v4` → `v6`
- `actions/github-script@v7` → `v8`

## Verification

All updates verified via Context7 docs and GitHub releases:
- checkout@v6: No breaking changes for our use case (credential persistence change only affects Docker container actions)
- download-artifact@v6: Node.js 24 support, no functional breaking changes
- github-script@v8: Node.js 24 support

## Testing

- [ ] Test workflow passes
- [ ] All example workflows validated