### PR TITLE
fix: use versioned URL instead of /latest/ for downloads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,8 +74,8 @@ runs:
           exit 1
         fi
         
-        # Download URL (Linux only, always from /latest/ path)
-        DOWNLOAD_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/kirocli-${KIRO_ARCH}-linux.zip"
+        # Download URL (Linux only, versioned path)
+        DOWNLOAD_URL="https://desktop-release.q.us-east-1.amazonaws.com/${{ inputs.version }}/kirocli-${KIRO_ARCH}-linux.zip"
         echo "Downloading from: $DOWNLOAD_URL"
         
         # Download and extract


### PR DESCRIPTION
Fixes cache key mismatch bug.

**Problem**: 
- Cache key uses `inputs.version` (e.g., 1.21.0)
- Download URL uses `/latest/` path
- Mismatch causes cache to store wrong version

**Solution**: Use versioned URL path matching cache key.

**Changes**:
- Line 77: `/latest/` → `/${{ inputs.version }}/`

**Impact**:
- Cache now accurately reflects installed version
- Enables version pinning to work correctly
- Prepares for Renovate version tracking