### PR TITLE
feat: add Renovate config for automated version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^action\\.yml$"],
+      "matchStrings": ["default:\\s*['\"](?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]"],
+      "depNameTemplate": "kiro-cli",
+      "datasourceTemplate": "custom.kiro"
+    }
+  ],
+  "customDatasources": {
+    "kiro": {
+      "defaultRegistryUrlTemplate": "https://desktop-release.q.us-east-1.amazonaws.com/latest/manifest.json",
+      "transformTemplates": [
+        "{\"releases\": [{\"version\": version}]}"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds Renovate configuration with custom datasource to track Kiro CLI versions.

**How it works:**
- Regex manager matches version in `action.yml` (`default: '1.21.0'`)
- Custom datasource fetches AWS manifest.json
- JSONata extracts version field
- Renovate creates PR when new version detected

**Benefits:**
- Preserves YAML formatting (no yq rewrite)
- Zero maintenance
- Industry standard tool

**Next step:** Remove `check-version.yml` workflow (separate PR after testing Renovate)