### PR TITLE
chore: enable automerge for patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,11 @@
         "{\"releases\": [{\"version\": version}]}"
       ]
     }
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Configures Renovate to automerge patch version updates.

**Change:** Add `packageRules` to automerge only patch updates (e.g., 1.21.0 -> 1.21.1)

Minor and major updates still require manual review.