### PR TITLE
feat: enable merge queue with CI support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Add merge_group trigger and concurrency configuration to support GitHub merge queue.

Changes:
- Add merge_group event trigger to test.yml
- Add concurrency configuration to prevent duplicate workflow runs
- CI checks will now run when PRs are added to merge queue

This enables merge queue functionality once repository settings are configured.