### PR TITLE
fix(sigv4): correct AMAZON_Q_SIGV4 value to 1 and warn that kiro-cli-chat does not implement it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Verify SIGV4 environment variables
         run: |
-          if [ "$AMAZON_Q_SIGV4" != "true" ]; then
+          if [ "$AMAZON_Q_SIGV4" != "1" ]; then
             echo "ERROR: AMAZON_Q_SIGV4 not set correctly"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -159,15 +159,18 @@ Do not use `enable-sigv4: true` with long-lived IAM credentials (AKIA\* keys).
 
 ## How It Works
 
-On first run, the action downloads the Kiro CLI binary from AWS CDN and caches it at `~/.local/bin/`. Subsequent runs restore from cache. When `enable-sigv4` is set, the action exports `AMAZON_Q_SIGV4=true` for headless IAM authentication.
+On first run, the action downloads the Kiro CLI binary from AWS CDN and caches it at `~/.local/bin/`. Subsequent runs restore from cache. When `enable-sigv4` is set, the action exports `AMAZON_Q_SIGV4=1` for headless IAM authentication.
 
 > **SIGV4 Discovery:** The `AMAZON_Q_SIGV4` environment variable was discovered through source code analysis of the [amazon-q-developer-cli](https://github.com/aws/amazon-q-developer-cli) repository. It is an undocumented feature that enables headless IAM authentication for CI/CD environments.
+
+> [!WARNING]
+> **SIGV4 not yet implemented in `kiro-cli-chat`:** Amazon did not port SIGV4 authentication when migrating Q CLI to Kiro CLI. Setting `enable-sigv4: true` will emit a CI warning but has no functional effect. Track upstream progress at [kirodotdev/Kiro#5938](https://github.com/kirodotdev/Kiro/issues/5938). For working SIGV4 headless authentication today, use [clouatre-labs/setup-q-cli-action](https://github.com/clouatre-labs/setup-q-cli-action) instead.
 
 ## Troubleshooting
 
 **Binary not found:** Ensure the action step runs before any `kiro-cli-chat` invocation.
 
-**SIGV4 not working:** Verify `enable-sigv4: true` is set, AWS credentials are available, and the IAM role includes Amazon Q/Kiro permissions.
+**SIGV4 not working:** `AMAZON_Q_SIGV4` is not yet implemented in `kiro-cli-chat`. This is a known upstream limitation tracked at [kirodotdev/Kiro#5938](https://github.com/kirodotdev/Kiro/issues/5938). Use [clouatre-labs/setup-q-cli-action](https://github.com/clouatre-labs/setup-q-cli-action) for working SIGV4 support.
 
 **Cache not working:** The cache key includes OS and architecture. Changing runners creates a new cache entry - this is expected.
 

--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,8 @@ runs:
       if: inputs.enable-sigv4 == 'true'
       shell: bash
       run: | # zizmor: ignore[github-env,template-injection]
-        echo "AMAZON_Q_SIGV4=true" >> $GITHUB_ENV
+        echo "::warning::SIGV4 authentication (AMAZON_Q_SIGV4) is not yet implemented in kiro-cli-chat. The environment variable will be set but has no effect. Track upstream progress at https://github.com/kirodotdev/Kiro/issues/5938. For working SIGV4 support, use clouatre-labs/setup-q-cli-action instead."
+        echo "AMAZON_Q_SIGV4=1" >> $GITHUB_ENV
         echo "AWS_REGION=${{ inputs.aws-region }}" >> $GITHUB_ENV
 
     - name: Verify installation


### PR DESCRIPTION
## Summary

Fixes #61.

Two changes:

- Correct `AMAZON_Q_SIGV4` value from `true` to `1` (the documented and intended value used by Q CLI's source code)
- Add a `::warning::` CI annotation and README callout documenting that `AMAZON_Q_SIGV4` was not ported from Q CLI to `kiro-cli-chat`; setting `enable-sigv4: true` currently has no functional effect

Amazon did not remove SIGV4 from Kiro -- it was never implemented in `kiro-cli-chat` during the migration from Q CLI. This is tracked upstream at [kirodotdev/Kiro#5938](https://github.com/kirodotdev/Kiro/issues/5938).

Users who need working SIGV4 headless authentication today should use [clouatre-labs/setup-q-cli-action](https://github.com/clouatre-labs/setup-q-cli-action) instead.

## Changes

- `action.yml`: `AMAZON_Q_SIGV4=true` -> `AMAZON_Q_SIGV4=1`, add `::warning::` annotation
- `README.md`: fix value in How It Works, add `[!WARNING]` callout, update Troubleshooting entry

## Test plan

- [ ] CI passes
- [ ] `::warning::` annotation visible in Actions log when `enable-sigv4: true` is set

## Review checklist

- [x] No secrets or credentials in diff
- [x] Conventional commit with GPG + DCO sign-off
- [x] Upstream issue referenced (`kirodotdev/Kiro#5938`)