### PR TITLE
docs: use plain markdown badges for marketplace compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Setup Kiro CLI Action
 
-<p align="center">
-  <a href="https://github.com/marketplace/actions/setup-kiro-cli"><img alt="GitHub Marketplace" src="https://img.shields.io/badge/Marketplace-Setup%20Kiro%20CLI-blue?logo=github&style=for-the-badge" height="20"></a>
-  <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" height="20"></a>
-  <a href="https://www.bestpractices.dev/projects/12330"><img alt="OpenSSF Best Practices" src="https://img.shields.io/cii/level/12330?style=for-the-badge" height="20"></a>
-</p>
+[![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Setup%20Kiro%20CLI-blue?logo=github&style=flat-square)](https://github.com/marketplace/actions/setup-kiro-cli)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE)
+[![OpenSSF Best Practices](https://img.shields.io/cii/level/12330?style=flat-square)](https://www.bestpractices.dev/projects/12330)
 
-<p align="center">A GitHub Action that installs and caches <a href="https://kiro.dev/docs/cli/">Kiro CLI</a> for CI/CD workflows, with headless IAM authentication via SIGV4. OpenSSF silver certified: fewer than 1% of open source projects reach this level.</p>
+A GitHub Action that installs and caches [Kiro CLI](https://kiro.dev/docs/cli/) for CI/CD workflows, with headless IAM authentication via SIGV4. OpenSSF silver certified: fewer than 1% of open source projects reach this level.
 
 **Unofficial community action.** Not affiliated with or endorsed by Amazon Web Services. "Kiro" and "Amazon Web Services" are trademarks of AWS.
 


### PR DESCRIPTION
## Summary

Replace HTML badge blocks (`<p align="center"><a href=...><img ...></a></p>`) with plain markdown badge syntax. HTML tags do not render correctly on the GitHub Marketplace page; plain markdown badges display properly everywhere.

Mirrors the same fix applied to `clouatre-labs/aptu` in docs: use plain markdown badges for marketplace compatibility (aptu#1219).

## Changes

- `README.md`: replace `<p align="center">` badge block and `<p align="center">` description paragraph with native markdown badge lines and plain paragraph text
- Badge style changed from `for-the-badge` to `flat-square` to match the aptu convention

## Test plan

- [ ] Badges render correctly on GitHub repo page
- [ ] Badges render correctly on GitHub Marketplace listing
