### PR TITLE
chore: bump kiro default to 1.29.8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   version:
     description: 'Kiro CLI version to install'
     required: false
-    default: '1.28.1'
+    default: '1.29.8'
   aws-region:
     description: 'AWS region for Kiro CLI operations'
     required: false


### PR DESCRIPTION
## Summary

Bumps the default Kiro CLI version from 1.28.1 to 1.29.8.

## Changes

- `action.yml`: default version 1.28.1 -> 1.29.8

## Validation

- All GitHub Action SHAs (actions/checkout v6.0.2, actions/cache v5.0.5, zizmor-action v0.5.3) confirmed at latest.
- Kiro 1.29.8 confirmed available for x86_64-linux, aarch64-linux, and aarch64-linux-musl at the AWS release CDN.
