### PR TITLE
chore(renovate): automerge major github-actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
     {
       "groupName": "github-actions",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["patch", "minor", "digest", "pin", "lockFileMaintenance"],
+      "matchUpdateTypes": ["major", "minor", "patch", "digest", "pin", "lockFileMaintenance"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
Add `major` to `matchUpdateTypes` in the github-actions package rule so Renovate automerges major version bumps for GitHub Actions (e.g. actions/checkout v6 -> v7).

CI provides the safety gate: the full test matrix must pass before any automerge proceeds.

Same change as clouatre-labs/setup-goose-action#149.
