### PR TITLE
feat: add aptu dispatch handler workflow

### DIFF
--- a/.github/workflows/aptu.yml
+++ b/.github/workflows/aptu.yml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 aptu-github-app Contributors
+
+name: Aptu Dispatch Handler
+
+on:
+  repository_dispatch:
+    types:
+      - aptu-review
+      - aptu-triage
+      - aptu-scan-security
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  security-events: write
+  statuses: write
+
+jobs:
+  review:
+    name: Review PR
+    if: github.event.action == 'aptu-review'
+    uses: clouatre-labs/aptu-github-app/.github/workflows/pr-review.yml@main
+    with:
+      originating_repo: ${{ github.event.client_payload.originating_repo }}
+      pull_number: ${{ github.event.client_payload.pull_number }}
+      instructions_file: ${{ github.event.client_payload.instructions_file || '.github/instructions/pr-review.md' }}
+      skip_labeled: ${{ github.event.client_payload.skip_labeled || false }}
+      ai_provider: ${{ github.event.client_payload.ai_provider || 'openrouter' }}
+      ai_model: ${{ github.event.client_payload.ai_model || 'google/gemma-4-26b-a4b-it' }}
+    secrets:
+      ai-api-key: >-
+        ${{ (github.event.client_payload.ai_provider == 'anthropic' && secrets.ANTHROPIC_API_KEY)
+         || (github.event.client_payload.ai_provider == 'gemini' && secrets.GEMINI_API_KEY)
+         || secrets.OPENROUTER_API_KEY }}
+
+  triage:
+    name: Triage Issue
+    if: github.event.action == 'aptu-triage'
+    uses: clouatre-labs/aptu-github-app/.github/workflows/issue-triage.yml@main
+    with:
+      originating_repo: ${{ github.event.client_payload.originating_repo }}
+      issue_number: ${{ github.event.client_payload.issue_number }}
+      ai_provider: ${{ github.event.client_payload.ai_provider || 'openrouter' }}
+      ai_model: ${{ github.event.client_payload.ai_model || 'google/gemma-4-26b-a4b-it' }}
+    secrets:
+      ai-api-key: >-
+        ${{ (github.event.client_payload.ai_provider == 'anthropic' && secrets.ANTHROPIC_API_KEY)
+         || (github.event.client_payload.ai_provider == 'gemini' && secrets.GEMINI_API_KEY)
+         || secrets.OPENROUTER_API_KEY }}
+
+  scan:
+    name: Scan Security
+    if: github.event.action == 'aptu-scan-security'
+    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@main
+    with:
+      originating_repo: ${{ github.event.client_payload.originating_repo }}
+      head_sha: ${{ github.event.client_payload.head_sha }}
+      pull_number: ${{ github.event.client_payload.pull_number }}
+      scan_path: ${{ github.event.client_payload.scan_path || '.' }}
+      fail_on: ${{ github.event.client_payload.fail_on || '' }}


### PR DESCRIPTION
## Summary

Adds the `.github/workflows/aptu.yml` dispatch handler workflow, which is required for
`repository_dispatch` events from the aptu-github-app webhook to trigger triage, review, and
security scan jobs in this repository.

This file is byte-identical to the template documented in
[README.md](https://github.com/clouatre-labs/aptu-github-app/blob/main/README.md) and to the
file already deployed in `aptu-github-app` itself. No per-repo customization is needed.

## Background

Per the [BYOK rollout audit](https://github.com/clouatre-labs/aptu-github-app/blob/main/docs/audit/2026-08-byok-rollout-simplification.md)
(finding R1), this repo has `.github/aptu.yml` configured but was missing the dispatch handler
workflow file. Without it, every `repository_dispatch` event from the webhook silently no-ops:
GitHub requires the workflow file to already be committed on the default branch.

## What this does

- Adds a static workflow file that listens for `repository_dispatch` events of type
  `aptu-review`, `aptu-triage`, and `aptu-scan-security`
- Each job delegates to the corresponding reusable workflow in
  `clouatre-labs/aptu-github-app`
- AI API key resolution is automatic based on the `ai.provider` field in `.github/aptu.yml`
  (this repo uses `openrouter`, backed by the org-wide `OPENROUTER_API_KEY` secret)

## No secrets required

`OPENROUTER_API_KEY` is a `clouatre-labs` organization secret with visibility `all`. This repo
already inherits it. No secret setup is needed.

Closes clouatre-labs/aptu-github-app#174
