### PR TITLE
chore: remove dead api-key-secret field from aptu.yml

### DIFF
--- a/.github/aptu.yml
+++ b/.github/aptu.yml
@@ -11,4 +11,3 @@ scan:
 ai:
   provider: openrouter
   model: google/gemma-4-26b-a4b-it
-  api-key-secret: OPENROUTER_API_KEY


### PR DESCRIPTION
## Summary

The `ai.api-key-secret` field in `.github/aptu.yml` is vestigial. PR #170 in `aptu-github-app` removed `api-key-secret` from the `AiConfig` interface in `worker/src/config.ts`. The Worker no longer parses, validates, or forwards this field. It is silently ignored during config parsing.

The secret is now resolved statically in `.github/workflows/aptu.yml` via a provider-keyed OR-chain:

```yaml
secrets:
  ai-api-key: >-
    ${{ (github.event.client_payload.ai_provider == 'anthropic' && secrets.ANTHROPIC_API_KEY)
     || (github.event.client_payload.ai_provider == 'gemini' && secrets.GEMINI_API_KEY)
     || secrets.OPENROUTER_API_KEY }}
```

## Changes

- Removed `api-key-secret: OPENROUTER_API_KEY` from the `ai` block in `.github/aptu.yml`
- The `provider` and `model` fields remain unchanged

Ref: clouatre-labs/aptu-github-app#179