### PR TITLE
fix(ci): forward aptu-dev App credentials to reusable workflows

### DIFF
--- a/.github/workflows/aptu.yml
+++ b/.github/workflows/aptu.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/pr-review.yml@be3845a6f9d9059ff025d87f283c48ee35abbf1d # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/pr-review.yml@78b2c41720d69bf1e4e802fb2a3cbaf175092639 # main
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       pull_number: ${{ github.event.client_payload.pull_number }}
@@ -25,11 +25,13 @@ jobs:
       skip_labeled: ${{ github.event.client_payload.skip_labeled || false }}
       ai_provider: ${{ github.event.client_payload.ai_provider || 'openrouter' }}
       ai_model: ${{ github.event.client_payload.ai_model || 'google/gemma-4-26b-a4b-it' }}
+      app_id: ${{ vars.APP_ID }}
     secrets:
       ai-api-key: >-
         ${{ (github.event.client_payload.ai_provider == 'anthropic' && secrets.ANTHROPIC_API_KEY)
          || (github.event.client_payload.ai_provider == 'gemini' && secrets.GEMINI_API_KEY)
          || secrets.OPENROUTER_API_KEY }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
   triage:
     name: Triage Issue
@@ -37,17 +39,19 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/issue-triage.yml@be3845a6f9d9059ff025d87f283c48ee35abbf1d # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/issue-triage.yml@78b2c41720d69bf1e4e802fb2a3cbaf175092639 # main
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       issue_number: ${{ github.event.client_payload.issue_number }}
       ai_provider: ${{ github.event.client_payload.ai_provider || 'openrouter' }}
       ai_model: ${{ github.event.client_payload.ai_model || 'google/gemma-4-26b-a4b-it' }}
+      app_id: ${{ vars.APP_ID }}
     secrets:
       ai-api-key: >-
         ${{ (github.event.client_payload.ai_provider == 'anthropic' && secrets.ANTHROPIC_API_KEY)
          || (github.event.client_payload.ai_provider == 'gemini' && secrets.GEMINI_API_KEY)
          || secrets.OPENROUTER_API_KEY }}
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
   scan:
     name: Scan Security
@@ -56,10 +60,13 @@ jobs:
       contents: read
       security-events: write
       statuses: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@be3845a6f9d9059ff025d87f283c48ee35abbf1d # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@78b2c41720d69bf1e4e802fb2a3cbaf175092639 # main
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       head_sha: ${{ github.event.client_payload.head_sha }}
       pull_number: ${{ github.event.client_payload.pull_number }}
       scan_path: ${{ github.event.client_payload.scan_path || '.' }}
       fail_on: ${{ github.event.client_payload.fail_on || '' }}
+      app_id: ${{ vars.APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Updates all three aptu-github-app reusable workflow calls to pin to commit 78b2c417 and forward the new app_id input and app-private-key secret now required by aptu-github-app#191. Org-level vars.APP_ID and secrets.APP_PRIVATE_KEY are scoped to this repository.

- review job: pr-review.yml
- triage job: issue-triage.yml
- scan job: scan-security.yml

Closes #192

