### PR TITLE
chore: use server-minted installation token instead of raw App private key

### DIFF
--- a/.github/workflows/aptu-review.yml
+++ b/.github/workflows/aptu-review.yml
@@ -22,10 +22,9 @@ jobs:
       skip_labeled: ${{ github.event.client_payload.skip_labeled || false }}
       ai_provider: ${{ github.event.client_payload.ai_provider || 'openrouter' }}
       ai_model: ${{ github.event.client_payload.ai_model || 'google/gemma-4-26b-a4b-it' }}
-      app_id: ${{ vars.APP_ID }}
     secrets:
       ai-api-key: >-
         ${{ (github.event.client_payload.ai_provider == 'anthropic' && secrets.ANTHROPIC_API_KEY)
          || (github.event.client_payload.ai_provider == 'gemini' && secrets.GEMINI_API_KEY)
          || secrets.OPENROUTER_API_KEY }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      installation-token: ${{ github.event.client_payload.installation_token }}

--- a/.github/workflows/aptu-scan-security.yml
+++ b/.github/workflows/aptu-scan-security.yml
@@ -22,6 +22,5 @@ jobs:
       pull_number: ${{ github.event.client_payload.pull_number }}
       scan_path: ${{ github.event.client_payload.scan_path || '.' }}
       fail_on: ${{ github.event.client_payload.fail_on || '' }}
-      app_id: ${{ vars.APP_ID }}
     secrets:
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      installation-token: ${{ github.event.client_payload.installation_token }}

--- a/.github/workflows/aptu-triage.yml
+++ b/.github/workflows/aptu-triage.yml
@@ -20,10 +20,9 @@ jobs:
       issue_number: ${{ github.event.client_payload.issue_number }}
       ai_provider: ${{ github.event.client_payload.ai_provider || 'openrouter' }}
       ai_model: ${{ github.event.client_payload.ai_model || 'google/gemma-4-26b-a4b-it' }}
-      app_id: ${{ vars.APP_ID }}
     secrets:
       ai-api-key: >-
         ${{ (github.event.client_payload.ai_provider == 'anthropic' && secrets.ANTHROPIC_API_KEY)
          || (github.event.client_payload.ai_provider == 'gemini' && secrets.GEMINI_API_KEY)
          || secrets.OPENROUTER_API_KEY }}
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      installation-token: ${{ github.event.client_payload.installation_token }}


### PR DESCRIPTION
## Summary

Updates the 3 aptu caller handler workflows to use the server-minted installation token instead of the raw App private key.

## Context

PR [clouatre-labs/aptu-github-app#204](https://github.com/clouatre-labs/aptu-github-app/pull/204) moved installation token minting from caller-side `actions/create-github-app-token` into the Worker. These caller handler workflows no longer need `APP_ID` or `APP_PRIVATE_KEY`.

## Changes

- Removed `app_id: ${{ vars.APP_ID }}` from the `with:` block
- Replaced `app-private-key: ${{ secrets.APP_PRIVATE_KEY }}` with `installation-token: ${{ github.event.client_payload.installation_token }}` in the `secrets:` block
- Files: `aptu-review.yml`, `aptu-triage.yml`, `aptu-scan-security.yml`

## References

- [clouatre-labs/aptu-github-app#205](https://github.com/clouatre-labs/aptu-github-app/issues/205)
- [clouatre-labs/aptu-github-app#204](https://github.com/clouatre-labs/aptu-github-app/pull/204)
