### PR TITLE
fix: update reusable workflow SHA pin to PR #204 commit

### DIFF
--- a/.github/workflows/aptu-review.yml
+++ b/.github/workflows/aptu-review.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/pr-review.yml@56f54aa99b97cae128d0aa2237cafc91067e9ee9 # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/pr-review.yml@cebc66ea5e3c9a75e6286f3f7404ee7fadb799fa # main
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       pull_number: ${{ github.event.client_payload.pull_number }}

--- a/.github/workflows/aptu-scan-security.yml
+++ b/.github/workflows/aptu-scan-security.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       security-events: write
       statuses: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@56f54aa99b97cae128d0aa2237cafc91067e9ee9 # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@cebc66ea5e3c9a75e6286f3f7404ee7fadb799fa # main
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       head_sha: ${{ github.event.client_payload.head_sha }}

--- a/.github/workflows/aptu-triage.yml
+++ b/.github/workflows/aptu-triage.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/issue-triage.yml@56f54aa99b97cae128d0aa2237cafc91067e9ee9 # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/issue-triage.yml@cebc66ea5e3c9a75e6286f3f7404ee7fadb799fa # main
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       issue_number: ${{ github.event.client_payload.issue_number }}


### PR DESCRIPTION
## Summary

Updates the SHA pin in aptu caller handler workflows to reference the reusable workflows from PR #204, which expect `installation-token` instead of `app-private-key`.

## Context

PR [clouatre-labs/aptu-github-app#204](https://github.com/clouatre-labs/aptu-github-app/pull/204) changed the reusable workflows to accept `installation-token` instead of `app-private-key`. The caller workflows were updated to pass `installation-token`, but the SHA pin still references the pre-PR-204 commit. This mismatch causes `startup_failure` because the old reusable workflow expects `app-private-key` as a required secret.

## Changes

- Updated SHA pin from `56f54aa` to `cebc66e` in all 3 caller handler workflows
- Files: `aptu-review.yml`, `aptu-triage.yml`, `aptu-scan-security.yml`

## References

- [clouatre-labs/aptu-github-app#205](https://github.com/clouatre-labs/aptu-github-app/issues/205)
- [clouatre-labs/aptu-github-app#204](https://github.com/clouatre-labs/aptu-github-app/pull/204)
