### PR TITLE
fix: bump scan-security dispatcher pin to pick up diff-scoped scanning

### DIFF
--- a/.github/workflows/aptu-scan-security.yml
+++ b/.github/workflows/aptu-scan-security.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       security-events: write
       statuses: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@cebc66ea5e3c9a75e6286f3f7404ee7fadb799fa # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@0676ae328ab53d45a436893e666e9c46a4aff331 # main
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       head_sha: ${{ github.event.client_payload.head_sha }}


### PR DESCRIPTION
## Summary

- This repo's `aptu-scan-security.yml` pinned the reusable workflow to a stale commit that scanned full-repo instead of the PR diff, causing false-positive security-scan failures unrelated to actual PR changes.
- `clouatre-labs/aptu-github-app#212` fixed that (diff-scoped scanning, corrected status link), merged as `0676ae328ab53d45a436893e666e9c46a4aff331`.
- This bumps the pin to that commit. Verified working end-to-end on `clouatre-labs/career` PR #415/#416.

## Test plan

- [x] actionlint on the changed file
- [ ] Next PR against this repo should show a diff-scoped scan
