### PR TITLE
fix: re-pin aptu-*.yml dispatchers to v0.1.2

### DIFF
--- a/.github/workflows/aptu-review.yml
+++ b/.github/workflows/aptu-review.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/pr-review.yml@cebc66ea5e3c9a75e6286f3f7404ee7fadb799fa # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/pr-review.yml@4888f2bb807eaf4fef006d1eee3c174d92bd0d86 # v0.1.2
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       pull_number: ${{ github.event.client_payload.pull_number }}

--- a/.github/workflows/aptu-scan-security.yml
+++ b/.github/workflows/aptu-scan-security.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       security-events: write
       statuses: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@0676ae328ab53d45a436893e666e9c46a4aff331 # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/scan-security.yml@4888f2bb807eaf4fef006d1eee3c174d92bd0d86 # v0.1.2
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       head_sha: ${{ github.event.client_payload.head_sha }}

--- a/.github/workflows/aptu-triage.yml
+++ b/.github/workflows/aptu-triage.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: clouatre-labs/aptu-github-app/.github/workflows/issue-triage.yml@cebc66ea5e3c9a75e6286f3f7404ee7fadb799fa # main
+    uses: clouatre-labs/aptu-github-app/.github/workflows/issue-triage.yml@4888f2bb807eaf4fef006d1eee3c174d92bd0d86 # v0.1.2
     with:
       originating_repo: ${{ github.event.client_payload.originating_repo }}
       issue_number: ${{ github.event.client_payload.issue_number }}


### PR DESCRIPTION
## Summary
Re-pins the three `aptu-*.yml` dispatcher workflows to `clouatre-labs/aptu-github-app@v0.1.2`. They were previously pinned to an untagged, pre-release commit mislabeled `# main`, which meant they carried none of the fixes shipped since and could not be tracked against a real release.

## Related Issues

- Closes #N (if applicable)

## Changes

- `.github/workflows/aptu-review.yml`: re-pinned `pr-review.yml` from `cebc66ea5e3c9a75e6286f3f7404ee7fadb799fa # main` to `4888f2bb807eaf4fef006d1eee3c174d92bd0d86 # v0.1.2`
- `.github/workflows/aptu-triage.yml`: re-pinned `issue-triage.yml` from `cebc66ea5e3c9a75e6286f3f7404ee7fadb799fa # main` to `4888f2bb807eaf4fef006d1eee3c174d92bd0d86 # v0.1.2`
- `.github/workflows/aptu-scan-security.yml`: re-pinned `scan-security.yml` from `0676ae328ab53d45a436893e666e9c46a4aff331 # main` to `4888f2bb807eaf4fef006d1eee3c174d92bd0d86 # v0.1.2`

This brings in every bugfix shipped since the old pin, including a fix that surfaces silently-swallowed PR-review step failures. See the release notes: https://github.com/clouatre-labs/aptu-github-app/releases/tag/v0.1.2

## Test Plan

- `git diff` confirms exactly one changed line per file, no other content touched
- `grep -n "aptu-github-app/.github/workflows" .github/workflows/aptu-*.yml` confirms all three now point at `4888f2bb807eaf4fef006d1eee3c174d92bd0d86 # v0.1.2`
- `actionlint` run against the three modified workflows: clean, no findings

## Verification Checklist

- [ ] CI passes (CI Result green)
- [x] Commit GPG-signed: `git commit -S`
- [x] DCO signed-off: `git commit --signoff`
- [x] actionlint clean on modified workflows
- [x] No secrets, API keys, or credentials in diff
- [x] I have reviewed every line in this PR and can explain it
